### PR TITLE
Fix: Swap Windows registry seed color R/B channels

### DIFF
--- a/library/src/jvmMain/kotlin/dev/zwander/compose/ThemeInfo.jvm.kt
+++ b/library/src/jvmMain/kotlin/dev/zwander/compose/ThemeInfo.jvm.kt
@@ -62,7 +62,9 @@ actual fun rememberThemeInfo(isDarkMode: Boolean): ThemeInfo {
                             "Software\\Microsoft\\Windows\\DWM",
                             "AccentColor",
                         )
-                    ).rgb
+                    ).let {
+                        Color(it.blue, it.green, it.red).toArgb()
+                    }
                 } catch (_: Throwable) {
                     try {
                         Color(
@@ -71,7 +73,7 @@ actual fun rememberThemeInfo(isDarkMode: Boolean): ThemeInfo {
                                 "Software\\Microsoft\\Windows\\DWM",
                                 "ColorizationColor",
                             )
-                        ).copy(alpha = 1f).toArgb()
+                        ).toArgb()
                     } catch (_: Throwable) {
                         println("Unable to retrieve Windows accent color.")
                         defaultColor.toArgb()


### PR DESCRIPTION
Resolved #3 by appropriately swapping the red and blue channels of `Software\Microsoft\Windows\DWM\AccentColor`, which is stored in `ABGR` (previous code expected `ARGB`).

The fallback to `Software\Microsoft\Windows\DWM\ColorizationColor` is left unchanges, as this value _is_ actually in `ARGB`.